### PR TITLE
Add OGR subtypes

### DIFF
--- a/src/pyspark_vector_files/__init__.py
+++ b/src/pyspark_vector_files/__init__.py
@@ -189,15 +189,18 @@ from contextlib import contextmanager
 from types import MappingProxyType
 from typing import Iterator, Optional, Union
 
-from numpy import float32, int32, int64, object0
+from numpy import bool_, float32, float64, int16, int32, int64, object0
 from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.sql import SparkSession
 from pyspark.sql.types import (
     ArrayType,
     BinaryType,
+    BooleanType,
+    DoubleType,
     FloatType,
     IntegerType,
     LongType,
+    ShortType,
     StringType,
     StructType,
 )
@@ -231,34 +234,49 @@ from pyspark_vector_files._types import ConcurrencyStrategy
 
 OGR_TO_SPARK = MappingProxyType(
     {
-        "Binary": BinaryType(),
-        "Date": StringType(),
-        "DateTime": StringType(),
-        "Integer": IntegerType(),
-        "IntegerList": ArrayType(IntegerType()),
-        "Integer64": LongType(),
-        "Integer64List": ArrayType(LongType()),
-        "Real": FloatType(),
-        "RealList": ArrayType(FloatType()),
-        "String": StringType(),
-        "StringList": ArrayType(StringType()),
-        "Time": StringType(),
-        "WideString": StringType(),
-        "WideStringList": ArrayType(StringType()),
+        (0, 0): IntegerType(),  # OFTInteger
+        (0, 1): BooleanType(),  # OFSTBoolean
+        (0, 2): ShortType(),  # OFSTInt16
+        (1, 0): ArrayType(IntegerType()),  # OFTIntegerList
+        (1, 1): ArrayType(ShortType()),  # List of OFSTInt16
+        (1, 2): ArrayType(BooleanType()),  # List of OFSTBoolean
+        (2, 0): DoubleType(),  # OFTReal
+        (2, 3): FloatType(),  # OFSTFloat32
+        (3, 0): ArrayType(DoubleType()),  # OFTRealList
+        (3, 3): ArrayType(FloatType()),  # List of OFSTFloat32
+        (4, 0): StringType(),  # OFTString
+        # ? Could this be MapType?
+        (4, 4): StringType(),  # OFSTJSON
+        (4, 5): StringType(),  # OFSTUUID
+        (5, 0): ArrayType(StringType()),  # OFTStringList
+        (6, 0): StringType(),  # OFTWideString
+        (7, 0): ArrayType(StringType()),  # OFTWideStringList
+        (8, 0): BinaryType(),  # OFTBinary
+        (9, 0): StringType(),  # OFTDate
+        (10, 0): StringType(),  # OFTTime
+        (11, 0): StringType(),  # OFTDateTime
+        (12, 0): LongType(),  # OFTInteger64
+        (13, 0): ArrayType(LongType()),  # OFTInteger64List
     }
 )
 
 SPARK_TO_PANDAS = MappingProxyType(
     {
-        ArrayType(FloatType()): object0,
+        IntegerType(): int32,
+        BooleanType(): bool_,
+        ShortType(): int16,
         ArrayType(IntegerType()): object0,
-        ArrayType(LongType()): object0,
+        ArrayType(BooleanType()): object0,
+        ArrayType(ShortType()): object0,
+        DoubleType(): float64,
+        FloatType(): float32,
+        ArrayType(DoubleType()): object0,
+        ArrayType(FloatType()): object0,
+        StringType(): object0,
         ArrayType(StringType()): object0,
         BinaryType(): object0,
-        FloatType(): float32,
-        IntegerType(): int32,
         LongType(): int64,
-        StringType(): object0,
+        ArrayType(LongType()): object0,
     }
 )
 

--- a/src/pyspark_vector_files/__init__.py
+++ b/src/pyspark_vector_files/__init__.py
@@ -187,7 +187,7 @@ By default, a chunk will consist of 1 million rows but you can change this using
 """
 from contextlib import contextmanager
 from types import MappingProxyType
-from typing import Iterator, Optional, Union
+from typing import Iterator, Optional, Tuple, Union
 
 from numpy import bool_, float32, float64, int16, int32, int64, object0
 from pyspark.sql import DataFrame as SparkDataFrame
@@ -305,7 +305,7 @@ def read_vector_files(
     recursive: bool = False,
     ideal_chunk_size: int = 1_000_000,
     geom_field_name: str = "geometry",
-    geom_field_type: str = "Binary",
+    geom_field_type: Tuple[int, int] = (8, 0),
     coerce_to_schema: bool = False,
     spark_to_pandas_type_map: MappingProxyType = SPARK_TO_PANDAS,
     concurrency_strategy: str = "files",
@@ -335,8 +335,9 @@ def read_vector_files(
             Defaults to 1_000_000.
         geom_field_name (str): The name of the geometry column. Defaults to
             "geometry".
-        geom_field_type (str): The data type of the geometry column when it is
-            passed to Spark. Defaults to "Binary".
+        geom_field_type (Tuple[int, int]): The data type of the geometry column when
+            it is passed to Spark. Defaults to `(8, 0)`, which represents binary
+            data.
         coerce_to_schema (bool): If True, all files or chunks will be forced to
             fit the supplied schema. Missing columns will be added and additional
             columns will be removed. Defaults to False.

--- a/src/pyspark_vector_files/__init__.py
+++ b/src/pyspark_vector_files/__init__.py
@@ -245,7 +245,7 @@ OGR_TO_SPARK = MappingProxyType(
         (3, 0): ArrayType(DoubleType()),  # OFTRealList
         (3, 3): ArrayType(FloatType()),  # List of OFSTFloat32
         (4, 0): StringType(),  # OFTString
-        # ? Could this be MapType?
+        # ? Could OFSTJSON be MapType?
         (4, 4): StringType(),  # OFSTJSON
         (4, 5): StringType(),  # OFSTUUID
         (5, 0): ArrayType(StringType()),  # OFTStringList

--- a/src/pyspark_vector_files/_schema.py
+++ b/src/pyspark_vector_files/_schema.py
@@ -53,7 +53,7 @@ def _get_feature_schema(
     layer: Layer,
     ogr_to_spark_type_map: MappingProxyType,
     geom_field_name: str,
-    geom_field_type: str,
+    geom_field_type: Tuple[int, int],
 ) -> StructType:
     """Given a GDAL Layer and a data type mapping, return a PySpark DataFrame schema."""
     property_names = _get_property_names(layer=layer)
@@ -72,7 +72,7 @@ def _create_schema_for_files(
     path: str,
     layer_identifier: Optional[Union[str, int]],
     geom_field_name: str,
-    geom_field_type: str,
+    geom_field_type: Tuple[int, int],
     ogr_to_spark_type_map: MappingProxyType,
 ) -> StructType:
     """Returns a schema for a given layer in the first file in a list of file paths."""
@@ -103,7 +103,7 @@ def _create_schema_for_chunks(
     data_source: Optional[DataSource],
     layer_name: str,
     geom_field_name: str,
-    geom_field_type: str,
+    geom_field_type: Tuple[int, int],
     ogr_to_spark_type_map: MappingProxyType,
 ) -> StructType:
     """Returns a schema for a given layer in the first file in a list of file paths."""

--- a/src/pyspark_vector_files/_schema.py
+++ b/src/pyspark_vector_files/_schema.py
@@ -42,11 +42,10 @@ def _get_property_types(layer: Layer) -> Tuple[Tuple[int, int], ...]:
         layer_definition.GetFieldDefn(index)
         for index in range(layer_definition.GetFieldCount())
     )
-    type_codes = tuple(
+    return tuple(
         (field_definition.GetType(), field_definition.GetSubType())
         for field_definition in field_definitions
     )
-    return tuple((type_code, subtype_code) for type_code, subtype_code in type_codes)
 
 
 def _get_feature_schema(

--- a/tests/test__schema.py
+++ b/tests/test__schema.py
@@ -85,7 +85,7 @@ def test__get_feature_schema(
         layer=layer,
         ogr_to_spark_type_map=ogr_to_spark_mapping,
         geom_field_name="geometry",
-        geom_field_type="Binary",
+        geom_field_type=(8, 0),
     )
     assert schema == fileGDB_schema
 
@@ -102,7 +102,7 @@ def test__create_schema_for_chunks(
         data_source=data_source,
         layer_name="first",
         geom_field_name="geometry",
-        geom_field_type="Binary",
+        geom_field_type=(8, 0),
         ogr_to_spark_type_map=ogr_to_spark_mapping,
     )
     assert schema == fileGDB_schema
@@ -118,7 +118,7 @@ def test__create_schema_for_files(
         path=first_fileGDB_path,
         layer_identifier="first",
         geom_field_name="geometry",
-        geom_field_type="Binary",
+        geom_field_type=(8, 0),
         ogr_to_spark_type_map=ogr_to_spark_mapping,
     )
     assert schema == fileGDB_schema


### PR DESCRIPTION
Closes #14 by extending `OGR_TO_SPARK` and `SPARK_TO_PANDAS` lookups to include OGR subtypes such as `OFSTBoolean` and `OFSTFloat32`.

@aw-west-defra, I think this works but I haven't been able to test it with the dataset that was giving you trouble in the first place, can you double check it for me, please? 