### PR TITLE
Cumbersome reading of zipped vector files with `read_vector_files`

### DIFF
--- a/src/pyspark_vector_files/__init__.py
+++ b/src/pyspark_vector_files/__init__.py
@@ -372,11 +372,17 @@ def read_vector_files(
     """
     _concurrency_strategy = ConcurrencyStrategy(concurrency_strategy)
 
+    compressed = _check_compressed(path=path)
+
+    if compressed == True and vsi_prefix == None:
+        raise Exception("vsi_prefix must be provided for compressed files.")
+
     paths = _get_paths(
         path=path,
         pattern=pattern,
         suffix=suffix,
         recursive=recursive,
+        compressed=compressed
     )
 
     if vsi_prefix:

--- a/src/pyspark_vector_files/_files.py
+++ b/src/pyspark_vector_files/_files.py
@@ -17,13 +17,28 @@ from pyspark.sql.types import (
 
 from pyspark_vector_files._types import Chunks
 
+def _check_compressed(path: str
+) -> bool:
+    """Checks if a path is a compressed file."""
+    if path.endswith((".zip",".gz",".tar",".tgz")):
+        return True
+    else:
+        return False    
 
 def _get_paths(
-    path: str, pattern: str, suffix: str, recursive: bool
+    path: str, pattern: str, suffix: str, recursive: bool, compressed: bool
 ) -> Tuple[str, ...]:
     """Returns full paths for all files in a path, with the given suffix."""
-    _path = Path(path)
-
+    
+    if compressed == True:    
+        # get the directory
+        _path = Path(path).parent
+        # get the suffix 
+        suffix = Path(path).suffix
+        
+    else:
+        _path = Path(path)
+        
     if not _path.is_dir():
         raise NotADirectoryError(
             f'"{str(_path)}" is not a directory.',


### PR DESCRIPTION
Attempts to fix #22.

1) Adds a new hidden function `_check_compressed` to see if the provided path is pointing to a compressed file. This function is used within `read_vector_files` and also in `_get_paths`. 

2) Added a check to see that if a compressed file is provided, that a vsi_prefix has also been provided.

3) `_get_paths` has been modified to deal with compressed file inputs, avoiding an error even though they are not directories. The parent directory and suffix are extracted and used accoridngly to format the path(s). 

This may not be the best implementation, but I hope it is a small improvement in working with compressed files. Feedback/suggestions for modifications welcome! 

Future work could include automatically matching vsi_prefixes depending on suffix type, although you may want the user to remain in control of this. 