### PR TITLE
Use little endian WKB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
         run: poetry run nox -s isort black
   static-type-analysis:
     name: Static type analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
         run: poetry run nox -s mypy
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
         run: poetry run nox -s tests
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-deploy:
     name: Build and deploy documentation
     concurrency: ci-${{ github.ref }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   release:
     name: Build and publish release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   test_pypi:
     name: Test upload to PyPi
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/vulnerability-scanning.yml
+++ b/.github/workflows/vulnerability-scanning.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   vulnerability-scan:
     name: Vulnerability scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/src/pyspark_vector_files/_parallel_reader.py
+++ b/src/pyspark_vector_files/_parallel_reader.py
@@ -2,7 +2,7 @@ from itertools import compress
 from types import MappingProxyType
 from typing import Callable, Generator, Optional, Tuple, Union
 
-from osgeo.ogr import Feature, Layer, Open
+from osgeo.ogr import Feature, Layer, Open, wkbNDR
 from pandas import DataFrame as PandasDataFrame
 from pandas import Series
 from pyspark.sql.types import DataType, StructType
@@ -33,7 +33,7 @@ def _get_geometry(feature: Feature) -> Tuple[Optional[bytearray]]:
     """Given a GDAL Feature, return the geometry field, if there is one."""
     geometry = feature.GetGeometryRef()
     if geometry:
-        return (geometry.ExportToWkb(),)
+        return (geometry.ExportToWkb(wkbNDR),)
     else:
         return (None,)
 

--- a/tests/test__parallel_reader.py
+++ b/tests/test__parallel_reader.py
@@ -64,7 +64,7 @@ def test__get_properties(first_fileGDB_path: str) -> None:
             "first",
             (
                 bytearray(
-                    b"\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"  # noqa: B950
+                    b"\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"  # noqa: B950
                 ),
             ),
         ),

--- a/tests/test__schema.py
+++ b/tests/test__schema.py
@@ -70,7 +70,7 @@ def test__get_property_types(first_fileGDB_path: str) -> None:
     data_source = Open(first_fileGDB_path)
     layer = data_source.GetLayer()
     property_types = _get_property_types(layer=layer)
-    assert property_types == ("Integer64", "String")
+    assert property_types == ((12, 0), (4, 0))  # (OFTInteger64, OFTString)
 
 
 def test__get_feature_schema(


### PR DESCRIPTION
Closes #31 by:

- explicitly specifing `wkbNDR` in call to `.ExportToWkb` method in `pyspark_vector_files._parallel_reader._get_geometry`
- updating related test to compare to little endian WKB

Also fixes failing test caused by change to using integer tuples to represent OGR datatypes in v0.2.2 by:

- updating data type test to use integer tuples instead of names
